### PR TITLE
improv. rollback change

### DIFF
--- a/src/main/java/com/songoda/epicfurnaces/listeners/BlockListeners.java
+++ b/src/main/java/com/songoda/epicfurnaces/listeners/BlockListeners.java
@@ -124,7 +124,7 @@ public class BlockListeners implements Listener {
                     : block.getType(), level, furnace.getUses());
 
             // By cancelling the event we destroy any chance of items dropping form the furnace. This fixes the problem.
-            //furnace.dropItems(); No need to drop items. dropItemNaturally() will drop the items inside the furnance
+            furnace.dropItems();
 
             event.getBlock().setType(Material.AIR);
             event.getBlock().getLocation().getWorld().dropItemNaturally(event.getBlock().getLocation(), item);


### PR DESCRIPTION
Hello,

I don't know where do you see that dropItemNaturally will drop all furnace content. You set the block to AIR and the dropItemNaturally wimply drop custom furnace item with random offset, according to the Javadocs : https://hub.spigotmc.org/javadocs/spigot/org/bukkit/World.html#dropItemNaturally(org.bukkit.Location,org.bukkit.inventory.ItemStack)